### PR TITLE
Use reusable workflows for Terraform

### DIFF
--- a/.github/workflows/terraform-apply.yml
+++ b/.github/workflows/terraform-apply.yml
@@ -6,49 +6,12 @@ on:
     branches:
       - main
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref_name }}
+  cancel-in-progress: true
+
 jobs:
-  terraform:
-    name: "Terraform Apply"
-    runs-on: ubuntu-latest
-    steps:
-      - name: "Checkout repository"
-        uses: actions/checkout@v4
-
-      - name: Get Token From GitHub APP
-        id: get_token
-        uses: actions/create-github-app-token@v1
-        with:
-          app-id: ${{ vars.UNIR_TFM_APP_ID }}
-          private-key: ${{ secrets.UNIR_TFM_APP_PRIVATE_KEY }}
-          owner: ${{ github.repository_owner }}
-
-      - name: "Configure AWS credentials"
-        uses: aws-actions/configure-aws-credentials@v4.2.1
-        with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_KEY }}
-          aws-region: us-east-1
-
-      - name: "Setup Terraform"
-        uses: hashicorp/setup-terraform@v3
-
-      - name: "Terraform Format Check"
-        run: terraform fmt -check
-
-      - name: "Terraform Init"
-        run: terraform init -input=false
-
-      - name: "Terraform Validate"
-        run: terraform validate
-
-      - name: "Terraform Plan"
-        run: terraform plan -input=false
-        env:
-          TF_VAR_aws_access_key: ${{ secrets.AWS_ACCESS_KEY }}
-          TF_VAR_aws_secret_key: ${{ secrets.AWS_SECRET_KEY }}
-
-      - name: "Terraform Apply"
-        run: terraform apply -auto-approve -input=false
-        env:
-          TF_VAR_aws_access_key: ${{ secrets.AWS_ACCESS_KEY }}
-          TF_VAR_aws_secret_key: ${{ secrets.AWS_SECRET_KEY }}
+  apply-changes:
+    name: "Apply Changes"
+    uses: unir-tfm-devops/reusable-github-actions/.github/workflows/terraform-apply-aws.yml@main
+    secrets: inherit

--- a/.github/workflows/terraform-destroy.yml
+++ b/.github/workflows/terraform-destroy.yml
@@ -3,33 +3,12 @@ name: "Terraform Destroy"
 on:
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref_name }}
+  cancel-in-progress: true
+
 jobs:
-  destroy:
-    name: "Terraform Destroy"
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: "Checkout repository"
-        uses: actions/checkout@v4
-
-      - name: "Configure AWS credentials"
-        uses: aws-actions/configure-aws-credentials@v2
-        with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_KEY }}
-          aws-region: us-east-1
-
-      - name: "Setup Terraform"
-        uses: hashicorp/setup-terraform@v3
-
-      - name: "Terraform Init"
-        run: terraform init -input=false
-
-      - name: "Terraform Validate"
-        run: terraform validate
-
-      - name: "Terraform Destroy"
-        run: terraform destroy -auto-approve -input=false
-        env:
-          TF_VAR_aws_access_key: ${{ secrets.AWS_ACCESS_KEY }}
-          TF_VAR_aws_secret_key: ${{ secrets.AWS_SECRET_KEY }}
+  destroy-resources:
+    name: "Destroy Resources"
+    uses: unir-tfm-devops/reusable-github-actions/.github/workflows/terraform-destroy-aws.yml@main
+    secrets: inherit

--- a/.github/workflows/terraform-plan.yml
+++ b/.github/workflows/terraform-plan.yml
@@ -5,51 +5,12 @@ on:
     branches:
       - main
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref_name }}
+  cancel-in-progress: true
+
 jobs:
-  terraform:
-    name: "Terraform Plan"
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: "Checkout repository"
-        uses: actions/checkout@v4
-
-      - name: Get Token From GitHub APP
-        id: get_token
-        uses: actions/create-github-app-token@v1
-        with:
-          app-id: ${{ vars.UNIR_TFM_APP_ID }}
-          private-key: ${{ secrets.UNIR_TFM_APP_PRIVATE_KEY }}
-          owner: ${{ github.repository_owner }}
-
-      - name: "Configure AWS credentials"
-        uses: aws-actions/configure-aws-credentials@v4.2.1
-        with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_KEY }}
-          aws-region: us-east-1
-
-      - name: "Setup Terraform"
-        uses: hashicorp/setup-terraform@v3
-
-      - name: "Terraform Format Check"
-        run: terraform fmt -check
-
-      - name: "Terraform Init"
-        run: terraform init -input=false
-
-      - name: "Terraform Validate"
-        run: terraform validate
-
-      - name: "Terraform Plan"
-        run: terraform plan -out .planfile -input=false
-        env:
-          TF_VAR_aws_access_key: ${{ secrets.AWS_ACCESS_KEY }}
-          TF_VAR_aws_secret_key: ${{ secrets.AWS_SECRET_KEY }}
-
-      - name: Post PR comment
-        if: always()
-        uses: borchero/terraform-plan-comment@v2
-        with:
-          token: ${{ steps.get_token.outputs.token }}
-          planfile: .planfile
+  plan-changes:
+    name: "Plan Changes"
+    uses: unir-tfm-devops/reusable-github-actions/.github/workflows/terraform-plan-aws.yml@main
+    secrets: inherit


### PR DESCRIPTION
This pull request refactors the Terraform workflows to use reusable GitHub Actions, simplifying the workflow definitions and improving maintainability. The most important changes include replacing in-line job definitions with reusable workflows and adding concurrency controls to prevent overlapping executions.

### Refactoring to Reusable Workflows:
* [`.github/workflows/terraform-apply.yml`](diffhunk://#diff-0470b92c7ad1159fdc694ea0893bd0e8bfad6d78173537f0e062e5e01aaf7f5eL9-R17): Replaced the in-line Terraform apply job with a reusable workflow (`terraform-apply-aws.yml`) and inherited secrets for configuration.
* [`.github/workflows/terraform-destroy.yml`](diffhunk://#diff-9dff5fac2f6cd80e8a50601fc837a18f6f01c7d944821025562e97e3d9e74d25L6-R14): Replaced the in-line Terraform destroy job with a reusable workflow (`terraform-destroy-aws.yml`) and inherited secrets for configuration.
* [`.github/workflows/terraform-plan.yml`](diffhunk://#diff-1ca63e6aac27d170492851d93ed42746d3493ce0db3c6ee7422efa4b7e3f0b6dL8-R16): Replaced the in-line Terraform plan job with a reusable workflow (`terraform-plan-aws.yml`) and inherited secrets for configuration.

### Adding Concurrency Controls:
* `.github/workflows/terraform-apply.yml`, `.github/workflows/terraform-destroy.yml`, `.github/workflows/terraform-plan.yml`: Added concurrency groups to ensure only one workflow execution per branch at a time, with the ability to cancel in-progress workflows. [[1]](diffhunk://#diff-0470b92c7ad1159fdc694ea0893bd0e8bfad6d78173537f0e062e5e01aaf7f5eL9-R17) [[2]](diffhunk://#diff-9dff5fac2f6cd80e8a50601fc837a18f6f01c7d944821025562e97e3d9e74d25L6-R14) [[3]](diffhunk://#diff-1ca63e6aac27d170492851d93ed42746d3493ce0db3c6ee7422efa4b7e3f0b6dL8-R16)